### PR TITLE
Use eager-loading of owner and tags for `content`

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -41,12 +41,13 @@ Client <- R6::R6Class( # nolint
     add_auth = function() {
       httr::add_headers(Authorization = paste0("Key ", self$api_key))
     },
-    GET = function(path, writer = httr::write_memory(), parser = "text") {
+    GET = function(path, ..., writer = httr::write_memory(), parser = "text") {
       url <- paste0(self$server, "/__api__/v1", path)
       res <- httr::GET(
         url,
         self$add_auth(),
-        writer
+        writer,
+        ...
       )
       self$raise_error(res)
       httr::content(res, as = parser)

--- a/R/rsctable.R
+++ b/R/rsctable.R
@@ -15,7 +15,7 @@ rsctable <- function(content) {
 
   reactable::reactable(
     content,
-    searchable = TRUE,
+    searchable = FALSE,
     highlight = TRUE,
     showPageInfo = FALSE,
     rowStyle = list(cursor = "pointer"),
@@ -23,8 +23,17 @@ rsctable <- function(content) {
       window.open(rowInfo.row.url, '_blank')
     }"),
     columns = list(
+      id = reactable::colDef(show = FALSE),
       guid = reactable::colDef(show = FALSE),
+      title = reactable::colDef(show = FALSE),
+      description = reactable::colDef(show = FALSE),
+      content_category = reactable::colDef(show = FALSE),
       url = reactable::colDef(show = FALSE),
+      created_time = reactable::colDef(show = FALSE),
+      owner_guid = reactable::colDef(show = FALSE),
+      owner_first_name = reactable::colDef(show = FALSE),
+      owner_last_name = reactable::colDef(show = FALSE),
+      tags = reactable::colDef(show = FALSE),
       name = reactable::colDef(
         name = "Name",
         cell = function(value, index) {
@@ -47,7 +56,6 @@ rsctable <- function(content) {
           )
         }
       ),
-      title = reactable::colDef(show = FALSE),
       owner_username = reactable::colDef(
         name = "Owner",
         maxWidth = 175
@@ -62,7 +70,6 @@ rsctable <- function(content) {
         },
         maxWidth = 175
       ),
-      content_category = reactable::colDef(show = FALSE),
       updated_time = reactable::colDef(
         name = "Updated",
         align = "right",


### PR DESCRIPTION
- Remove searchable from `rsctable`
- Hide extraneous columns in `rsctable`