### PR TITLE
Copy edit docs

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -101,11 +101,10 @@ rsctable(all_content)
 
 ### Setup
 
-the client object:
+The client object:
 
-- validates your API key with the Connect server
-- ensures you are running a recent enough version of Connect
-- warns if you will be unable to see content images while you are developing your page
+- Validates your API key with the RStudio Connect server
+- Ensures you are running a recent enough version of Connect
 
 Use an `.Renviron` file to set the `CONNECT_SERVER` and `CONNECT_API_KEY`
 environment variables.
@@ -184,7 +183,7 @@ all_content %>%
 
 Once your content data are filtered, `rscpages` provides components for
 displaying information about them. The title, description, and preview image can be set
-[from the Connect dashboard.](https://docs.rstudio.com/connect/user/content-settings/#content-metadata)
+[from the RStudio Connect dashboard.](https://docs.rstudio.com/connect/user/content-settings/#content-metadata)
 For content deployed to Connect where no image has been supplied, a default image will be used.
 
 *Note:* In many cases, you will only see default images until your content is deployed.
@@ -217,5 +216,5 @@ the components if you want more control over searching and filtering.
 
 ![search and filter widgets](man/figures/README-search-filter-2.png)
 
-Once you're happy with the look of your page, Publish it to Connect.
+Once you're happy with the look of your page, Publish it to RStudio Connect.
 Read more at `vignette("publishing")`.

--- a/README.Rmd
+++ b/README.Rmd
@@ -37,7 +37,7 @@ remotes::install_github("rstudio/rscpages")
 Use the template:
 
 ```{r, eval=FALSE}
-rmarkdown::draft("example-page.Rmd", template = "rscpages", package = "rscpages")`
+rmarkdown::draft("example-page.Rmd", template = "rscpages", package = "rscpages")
 ```
 
 You can also copy and knit the following example, or read on for more details:


### PR DESCRIPTION
- Removes a trailing backtick
- Some capitalization changes
- Formalizes "RStudio Connect" instead of "Connect" at the first mention in each section/paragraph as per RStudio marketing directives