### PR TITLE
content() should only return published content

### DIFF
--- a/R/content.R
+++ b/R/content.R
@@ -4,6 +4,8 @@
 #' return content that is visible to the API key's user account.
 #'
 #' @param client A Client object (see `connect`)
+#' @param unpublished A boolean value specifying whether to return content that
+#'   has not successfully published
 #'
 #' @return A data frame (tibble) of content items
 #'
@@ -31,10 +33,14 @@
 #'   }
 #'
 #' @export
-content <- function(client) {
+content <- function(client, unpublished = FALSE) {
   df <- client$content()
 
-  content_tbl <- tibble::tibble(
+  if (!unpublished) {
+    df <- df %>% dplyr::filter(!is.na(.data$bundle_id))
+  }
+
+  tibble::tibble(
     id = as.integer(df$id),
     guid = df$guid,
     name = df$name,

--- a/R/theming.R
+++ b/R/theming.R
@@ -236,7 +236,7 @@ table_pagination_styles <- function(theme_vars = NULL) {
     page_btns_current_style["backgroundColor"] <- theme_vars[["primary"]]
     page_btns_current_style["border"] <- "none"
 
-    return (
+    return(
       list(
         styles = page_btns_style,
         current_styles = page_btns_current_style

--- a/man/content.Rd
+++ b/man/content.Rd
@@ -4,10 +4,13 @@
 \alias{content}
 \title{Get Content Items}
 \usage{
-content(client)
+content(client, unpublished = FALSE)
 }
 \arguments{
 \item{client}{A Client object (see \code{connect})}
+
+\item{unpublished}{A boolean value specifying whether to return content that
+has not successfully published}
 }
 \value{
 A data frame (tibble) of content items


### PR DESCRIPTION
Provide a param for also including "unpublished" content.  Content is considered "published" if there is an associated `bundle_id`.